### PR TITLE
fix: replace LegacyScript with DeprecatedFeature in pipeline lint rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ lint:
   pipeline:
     deprecatedFeature:
       enabled: true
+      allowCELScript: false
+      allowDraft: false
+      allowStateFlow: false
     insecureAuthorization:
       enabled: false
     stepLength:
@@ -76,11 +79,11 @@ lint:
       enabled: true
     queryBeforeMutation:
       enabled: true
-    legacyScript:
-      enabled: true
   tailordb:
     deprecatedFeature:
       enabled: true
+      allowDraft: false
+      allowCELHooks: false
     legacyPermission:
       enabled: true
   stateflow:
@@ -91,24 +94,32 @@ lint:
 ### Lint Rules
 
 #### Pipeline Rules
-- **deprecatedFeature** - Check for deprecated features in pipelines
+- **deprecatedFeature** - Identify deprecated features including legacy script/validation patterns and recommend modern alternatives
+  - `enabled` (default: true) - Enable/disable deprecated feature detection
+  - `allowCELScript` (default: false) - Allow CEL script usage in pipelines
+  - `allowDraft` (default: false) - Allow draft resources in pipeline configurations
+  - `allowStateFlow` (default: false) - Allow StateFlow resources in pipeline configurations
+  - Detects legacy script patterns (`pre_validation`, `pre_script`, `post_script`, `post_validation`) and recommends modern hook alternatives (`pre_hook`, `post_hook`)
+  - Enabled by default to promote migration away from deprecated features
 - **insecureAuthorization** - Detect insecure authorization patterns
 - **stepLength** - Ensure pipeline steps don't exceed maximum length
 - **multipleMutations** - Identify multiple mutations in a single operation
 - **queryBeforeMutation** - Check for queries before mutations
-- **legacyScript** - Identify legacy script/validation patterns and recommend modern hook alternatives
-  - Detects `pre_validation` and recommends `pre_hook`
-  - Detects `pre_script` and recommends `pre_hook`
-  - Detects `post_script` and recommends `post_hook`
-  - Detects `post_validation` and recommends `post_hook`
-  - Enabled by default to promote migration to modern hook patterns
 
 #### TailorDB Rules
-- **deprecatedFeature** - Check for deprecated TailorDB features
+- **deprecatedFeature** - Identify deprecated TailorDB features and promote modern alternatives
+  - `enabled` (default: true) - Enable/disable deprecated feature detection
+  - `allowDraft` (default: false) - Allow draft resources in TailorDB configurations
+  - `allowCELHooks` (default: false) - Allow CEL hook usage in TailorDB configurations
+  - Detects deprecated patterns and recommends modern TailorDB alternatives
+  - Enabled by default to promote migration away from deprecated features
 - **legacyPermission** - Identify legacy permission patterns
 
-#### Stateflow Rules
-- **deprecatedFeature** - Check for deprecated Stateflow features
+#### StateFlow Rules
+- **deprecatedFeature** - Identify deprecated StateFlow features and promote modern alternatives
+  - `enabled` (default: true) - Enable/disable deprecated feature detection
+  - Detects deprecated StateFlow patterns and recommends modern alternatives
+  - Enabled by default to promote migration away from deprecated features
 
 ## Command Reference
 

--- a/config/config.go
+++ b/config/config.go
@@ -25,13 +25,13 @@ type Pipeline struct {
 	StepLength            StepLength                `yaml:"stepLength,omitempty,omitzero"`
 	MultipleMutations     MultipleMutations         `yaml:"multipleMutations,omitempty,omitzero"`
 	QueryBeforeMutation   QueryBeforeMutation       `yaml:"queryBeforeMutation,omitempty,omitzero"`
-	LegacyScript          LegacyScript              `yaml:"legacyScript,omitempty,omitzero"`
 }
 
 type PipelineDeprecatedFeature struct {
 	Enabled        bool `default:"true" yaml:"enabled,omitempty"`
 	AllowDraft     bool `default:"false" yaml:"allowDraft,omitempty"`
 	AllowStateFlow bool `default:"false" yaml:"allowStateFlow,omitempty"`
+	AllowCELScript bool `default:"false" yaml:"allowCELScript,omitempty"`
 }
 
 type InsecureAuthorization struct {
@@ -48,10 +48,6 @@ type MultipleMutations struct {
 }
 
 type QueryBeforeMutation struct {
-	Enabled bool `default:"true" yaml:"enabled,omitempty"`
-}
-
-type LegacyScript struct {
 	Enabled bool `default:"true" yaml:"enabled,omitempty"`
 }
 

--- a/tailor/helper_test.go
+++ b/tailor/helper_test.go
@@ -36,9 +36,7 @@ func createTestConfig(t *testing.T) *config.Config {
 					Enabled:        true,
 					AllowStateFlow: false,
 					AllowDraft:     false,
-				},
-				LegacyScript: config.LegacyScript{
-					Enabled: true,
+					AllowCELScript: false,
 				},
 				MultipleMutations: config.MultipleMutations{
 					Enabled: true,

--- a/tailor/lint.go
+++ b/tailor/lint.go
@@ -142,33 +142,33 @@ func (c *Client) Lint(resources *Resources) ([]*LintWarn, error) {
 						}
 					}
 				}
-				if c.cfg.Lint.Pipeline.LegacyScript.Enabled {
+				if c.cfg.Lint.Pipeline.DeprecatedFeature.Enabled && !c.cfg.Lint.Pipeline.DeprecatedFeature.AllowCELScript {
 					if s.PreValidation != "" {
 						warns = append(warns, &LintWarn{
 							Type:    LintTargetTypePipeline,
 							Name:    fmt.Sprintf("%s/%s step %s", p.NamespaceName, r.Name, s.Name),
-							Message: "`pre_validation` is not recommended. Use `pre_hook` instead.",
+							Message: "`pre_validation` is deprecated. Use `pre_hook` instead.",
 						})
 					}
 					if s.PreScript != "" {
 						warns = append(warns, &LintWarn{
 							Type:    LintTargetTypePipeline,
 							Name:    fmt.Sprintf("%s/%s step %s", p.NamespaceName, r.Name, s.Name),
-							Message: "`pre_script` is not recommended. Use `pre_hook` instead.",
+							Message: "`pre_script` is deprecated. Use `pre_hook` instead.",
 						})
 					}
 					if s.PostScript != "" {
 						warns = append(warns, &LintWarn{
 							Type:    LintTargetTypePipeline,
 							Name:    fmt.Sprintf("%s/%s step %s", p.NamespaceName, r.Name, s.Name),
-							Message: "`post_script` is not recommended. Use `post_hook` instead.",
+							Message: "`post_script` is deprecated. Use `post_hook` instead.",
 						})
 					}
 					if s.PostValidation != "" {
 						warns = append(warns, &LintWarn{
 							Type:    LintTargetTypePipeline,
 							Name:    fmt.Sprintf("%s/%s step %s", p.NamespaceName, r.Name, s.Name),
-							Message: "`post_validation` is not recommended. Use `post_hook` instead.",
+							Message: "`post_validation` is deprecated. Use `post_hook` instead.",
 						})
 					}
 				}

--- a/tailor/lint_test.go
+++ b/tailor/lint_test.go
@@ -284,7 +284,8 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 		{
 			name: "legacy script warnings",
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.LegacyScript.Enabled = true
+				c.Lint.Pipeline.DeprecatedFeature.Enabled = true
+				c.Lint.Pipeline.DeprecatedFeature.AllowCELScript = false
 			},
 			resources: &Resources{
 				Pipelines: []*Pipeline{
@@ -308,10 +309,10 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 				},
 			},
 			expectedMsgs: []string{
-				"`pre_validation` is not recommended. Use `pre_hook` instead.",
-				"`pre_script` is not recommended. Use `pre_hook` instead.",
-				"`post_script` is not recommended. Use `post_hook` instead.",
-				"`post_validation` is not recommended. Use `post_hook` instead.",
+				"`pre_validation` is deprecated. Use `pre_hook` instead.",
+				"`pre_script` is deprecated. Use `pre_hook` instead.",
+				"`post_script` is deprecated. Use `post_hook` instead.",
+				"`post_validation` is deprecated. Use `post_hook` instead.",
 			},
 		},
 		{


### PR DESCRIPTION
This pull request consolidates and enhances the handling of deprecated features in pipeline and TailorDB configurations. It removes the separate `legacyScript` lint rule in favor of a more flexible and comprehensive `deprecatedFeature` rule, adds new configuration options for fine-grained control, and updates documentation and test cases to reflect these changes.

**Lint Rule Consolidation and Configuration Enhancements:**

* Removed the standalone `legacyScript` lint rule and merged its functionality into the `deprecatedFeature` rule for pipelines, making deprecated script/validation checks part of a unified rule with new configuration options such as `allowCELScript`, `allowDraft`, and `allowStateFlow` in `PipelineDeprecatedFeature` (`config/config.go`, `README.md`). [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L28-R34) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L54-L57) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R72) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R86) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R122)

* Added `allowCELScript` and `allowCELHooks` options to the pipeline and TailorDB `deprecatedFeature` rules, allowing users to control whether certain deprecated patterns are permitted (`config/config.go`, `README.md`). [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L28-R34) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R70-R72) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L79-R86) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L94-R122)

**Lint Logic and Messaging Updates:**

* Updated linting logic to use the new `deprecatedFeature` options, and changed warning messages for deprecated script/validation patterns to clearly state they are deprecated and recommend modern alternatives (`tailor/lint.go`).

**Documentation Improvements:**

* Expanded documentation in `README.md` to describe the new configuration options and clarify the scope and purpose of the `deprecatedFeature` rule for pipelines, TailorDB, and StateFlow (`README.md`).

**Test Case Updates:**

* Updated test configurations and expected warning messages to align with the new rule structure and messaging, ensuring tests reflect the merged and enhanced `deprecatedFeature` rule (`tailor/helper_test.go`, `tailor/lint_test.go`). [[1]](diffhunk://#diff-6cb9066d2205a07393310e94855f2cc4c49d309bf2d73a23199f012d96fac01bL39-R39) [[2]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL287-R288) [[3]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL311-R315)