### PR TITLE
fix: replace legacy permission support to deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The metrics command outputs detailed JSON data about your workspace resources.
 Patterner uses a `.patterner.yml` file for configuration. The configuration includes various lint rules for different Tailor Platform components:
 
 ```yaml
+workspaceID: xxxxxxxXXxxxxxxxxxxxxx
 lint:
   pipeline:
     deprecatedFeature:
@@ -106,8 +107,6 @@ lint:
       enabled: true
       allowDraft: false
       allowCELHooks: false
-    legacyPermission:
-      enabled: true
   stateflow:
     deprecatedFeature:
       enabled: true
@@ -116,12 +115,13 @@ lint:
 ### Lint Rules
 
 #### Pipeline Rules
-- **deprecatedFeature** - Identify deprecated features including legacy script/validation patterns and recommend modern alternatives
+- **deprecatedFeature** - Identify deprecated features and promote modern alternatives
   - `enabled` (default: true) - Enable/disable deprecated feature detection
   - `allowCELScript` (default: false) - Allow CEL script usage in pipelines
   - `allowDraft` (default: false) - Allow draft resources in pipeline configurations
   - `allowStateFlow` (default: false) - Allow StateFlow resources in pipeline configurations
-  - Detects legacy script patterns (`pre_validation`, `pre_script`, `post_script`, `post_validation`) and recommends modern hook alternatives (`pre_hook`, `post_hook`)
+  - Detects deprecated patterns and recommends modern Pipeline alternatives
+      - https://docs.tailor.tech/reference/service-lifecycle-policy
   - Enabled by default to promote migration away from deprecated features
 - **insecureAuthorization** - Detect insecure authorization patterns
 - **stepLength** - Ensure pipeline steps don't exceed maximum length
@@ -134,13 +134,14 @@ lint:
   - `allowDraft` (default: false) - Allow draft resources in TailorDB configurations
   - `allowCELHooks` (default: false) - Allow CEL hook usage in TailorDB configurations
   - Detects deprecated patterns and recommends modern TailorDB alternatives
+      - https://docs.tailor.tech/reference/service-lifecycle-policy
   - Enabled by default to promote migration away from deprecated features
-- **legacyPermission** - Identify legacy permission patterns
 
 #### StateFlow Rules
 - **deprecatedFeature** - Identify deprecated StateFlow features and promote modern alternatives
   - `enabled` (default: true) - Enable/disable deprecated feature detection
   - Detects deprecated StateFlow patterns and recommends modern alternatives
+      - https://docs.tailor.tech/reference/service-lifecycle-policy
   - Enabled by default to promote migration away from deprecated features
 
 ## Command Reference

--- a/config/config.go
+++ b/config/config.go
@@ -53,17 +53,12 @@ type QueryBeforeMutation struct {
 
 type TailorDB struct {
 	DeprecatedFeature TailorDBDeprecatedFeature `yaml:"deprecatedFeature,omitempty,omitzero"`
-	LegacyPermission  LegacyPermission          `yaml:"legacyPermission,omitempty,omitzero"`
 }
 
 type TailorDBDeprecatedFeature struct {
-	Enabled       bool `default:"true" yaml:"enabled,omitempty"`
-	AllowDraft    bool `default:"false" yaml:"allowDraft,omitempty"`
-	AllowCELHooks bool `default:"false" yaml:"allowCELHooks,omitempty"`
-}
-
-type LegacyPermission struct {
 	Enabled               bool `default:"true" yaml:"enabled,omitempty"`
+	AllowDraft            bool `default:"false" yaml:"allowDraft,omitempty"`
+	AllowCELHooks         bool `default:"false" yaml:"allowCELHooks,omitempty"`
 	AllowTypePermission   bool `default:"false" yaml:"allowTypePermission,omitempty"`
 	AllowRecordPermission bool `default:"false" yaml:"allowRecordPermission,omitempty"`
 }

--- a/tailor/helper_test.go
+++ b/tailor/helper_test.go
@@ -14,12 +14,9 @@ func createTestConfig(t *testing.T) *config.Config {
 		Lint: config.Lint{
 			TailorDB: config.TailorDB{
 				DeprecatedFeature: config.TailorDBDeprecatedFeature{
-					Enabled:       true,
-					AllowDraft:    false,
-					AllowCELHooks: false,
-				},
-				LegacyPermission: config.LegacyPermission{
 					Enabled:               true,
+					AllowDraft:            false,
+					AllowCELHooks:         false,
 					AllowTypePermission:   false,
 					AllowRecordPermission: false,
 				},

--- a/tailor/lint.go
+++ b/tailor/lint.go
@@ -44,21 +44,18 @@ func (c *Client) Lint(resources *Resources) ([]*LintWarn, error) {
 						Message: "Draft feature is deprecated",
 					})
 				}
-			}
-
-			if c.cfg.Lint.TailorDB.LegacyPermission.Enabled {
-				if !c.cfg.Lint.TailorDB.LegacyPermission.AllowTypePermission && t.TypePermission != nil {
+				if !c.cfg.Lint.TailorDB.DeprecatedFeature.AllowTypePermission && t.TypePermission != nil {
 					warns = append(warns, &LintWarn{
 						Type:    LintTargetTypeTailorDB,
 						Name:    fmt.Sprintf("%s/%s", db.NamespaceName, t.Name),
-						Message: "Type-level permission is legacy. Use `Permission` or `GQLPermission` instead",
+						Message: "Type-level permission is deprecated. Use `Permission` or `GQLPermission` instead",
 					})
 				}
-				if !c.cfg.Lint.TailorDB.LegacyPermission.AllowRecordPermission && t.RecordPermission != nil {
+				if !c.cfg.Lint.TailorDB.DeprecatedFeature.AllowRecordPermission && t.RecordPermission != nil {
 					warns = append(warns, &LintWarn{
 						Type:    LintTargetTypeTailorDB,
 						Name:    fmt.Sprintf("%s/%s", db.NamespaceName, t.Name),
-						Message: "Record-level permission is legacy. Use `Permission` or `GQLPermission` instead",
+						Message: "Record-level permission is deprecated. Use `Permission` or `GQLPermission` instead",
 					})
 				}
 			}

--- a/tailor/lint_test.go
+++ b/tailor/lint_test.go
@@ -126,8 +126,8 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 		{
 			name: "legacy type permission warning",
 			configMod: func(c *config.Config) {
-				c.Lint.TailorDB.LegacyPermission.Enabled = true
-				c.Lint.TailorDB.LegacyPermission.AllowTypePermission = false
+				c.Lint.TailorDB.DeprecatedFeature.Enabled = true
+				c.Lint.TailorDB.DeprecatedFeature.AllowTypePermission = false
 			},
 			resources: &Resources{
 				TailorDBs: []*TailorDB{
@@ -142,13 +142,13 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 					},
 				},
 			},
-			expectedMsgs: []string{"Type-level permission is legacy. Use `Permission` or `GQLPermission` instead"},
+			expectedMsgs: []string{"Type-level permission is deprecated. Use `Permission` or `GQLPermission` instead"},
 		},
 		{
 			name: "legacy record permission warning",
 			configMod: func(c *config.Config) {
-				c.Lint.TailorDB.LegacyPermission.Enabled = true
-				c.Lint.TailorDB.LegacyPermission.AllowRecordPermission = false
+				c.Lint.TailorDB.DeprecatedFeature.Enabled = true
+				c.Lint.TailorDB.DeprecatedFeature.AllowRecordPermission = false
 			},
 			resources: &Resources{
 				TailorDBs: []*TailorDB{
@@ -163,7 +163,7 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 					},
 				},
 			},
-			expectedMsgs: []string{"Record-level permission is legacy. Use `Permission` or `GQLPermission` instead"},
+			expectedMsgs: []string{"Record-level permission is deprecated. Use `Permission` or `GQLPermission` instead"},
 		},
 		{
 			name: "CEL hooks deprecated warning",


### PR DESCRIPTION
This pull request consolidates the handling of deprecated and legacy permission patterns in TailorDB linting, streamlining configuration and messaging. The main change is the removal of the separate `legacyPermission` lint rule and its integration into the existing `deprecatedFeature` rule, both in configuration and code. Documentation and tests are updated accordingly for clarity and consistency.

**Configuration and Lint Rule Simplification:**

* Removed the `legacyPermission` lint rule from the `.patterner.yml` configuration and merged its functionality into the `deprecatedFeature` rule for TailorDB, simplifying the config structure and reducing duplication. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L109-L110) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L56-L66)
* Updated the `deprecatedFeature` rule in documentation and code to cover detection of both deprecated features and legacy permission patterns, and clarified the description and relevant documentation links. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L119-R124) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R137-R144)

**Code and Test Refactoring:**

* Refactored code in `tailor/lint.go` to check for deprecated type and record permissions under `DeprecatedFeature` instead of the removed `LegacyPermission`, and updated warning messages to use "deprecated" terminology.
* Updated tests in `tailor/lint_test.go` and test configuration in `tailor/helper_test.go` to use the new structure and to expect "deprecated" instead of "legacy" in warning messages. [[1]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL129-R130) [[2]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL145-R151) [[3]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL166-R166) [[4]](diffhunk://#diff-6cb9066d2205a07393310e94855f2cc4c49d309bf2d73a23199f012d96fac01bL20-L22)

**Documentation Update:**

* Added missing `workspaceID` field to the example configuration in `README.md` for completeness.