### PR TITLE
feat: add configurable acceptable warning threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,30 +87,40 @@ Patterner uses a `.patterner.yml` file for configuration. The configuration incl
 ```yaml
 workspaceID: xxxxxxxXXxxxxxxxxxxxxx
 lint:
-  pipeline:
-    deprecatedFeature:
-      enabled: true
-      allowCELScript: false
-      allowDraft: false
-      allowStateFlow: false
-    insecureAuthorization:
-      enabled: false
-    stepLength:
-      enabled: true
-      max: 30
-    multipleMutations:
-      enabled: true
-    queryBeforeMutation:
-      enabled: true
-  tailordb:
-    deprecatedFeature:
-      enabled: true
-      allowDraft: false
-      allowCELHooks: false
-  stateflow:
-    deprecatedFeature:
-      enabled: true
+  acceptable: 5
+  rules:
+    pipeline:
+      deprecatedFeature:
+        enabled: true
+        allowCELScript: false
+        allowDraft: false
+        allowStateFlow: false
+      insecureAuthorization:
+        enabled: false
+      stepLength:
+        enabled: true
+        max: 30
+      multipleMutations:
+        enabled: true
+      queryBeforeMutation:
+        enabled: true
+    tailordb:
+      deprecatedFeature:
+        enabled: true
+        allowDraft: false
+        allowCELHooks: false
+    stateflow:
+      deprecatedFeature:
+        enabled: true
 ```
+
+### Lint Configuration
+
+#### Acceptable Warnings
+- **acceptable** - Set the maximum number of acceptable lint warnings (default: 0)
+  - When the number of warnings exceeds this value, the lint command will exit with a failure status
+  - This allows you to gradually improve code quality by setting a reasonable warning threshold
+  - Example: `acceptable: 5` allows up to 5 warnings before failing
 
 ### Lint Rules
 

--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -22,7 +22,6 @@ THE SOFTWARE.
 package cmd
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
@@ -58,8 +57,11 @@ var lintCmd = &cobra.Command{
 		for _, w := range warns {
 			fmt.Printf("[%s] %s: %s\n", w.Type, w.Name, w.Message)
 		}
-		if len(warns) > 0 {
-			return errors.New("lint warnings found")
+		if len(warns) > cfg.Lint.Acceptable {
+			if cfg.Lint.Acceptable == 0 {
+				return fmt.Errorf("%d warnings found", len(warns))
+			}
+			return fmt.Errorf("%d warnings found, which exceeds the acceptable number of %d", len(warns), cfg.Lint.Acceptable)
 		}
 		return nil
 	},

--- a/config/config.go
+++ b/config/config.go
@@ -14,6 +14,11 @@ type Config struct {
 }
 
 type Lint struct {
+	Acceptable int   `default:"0" yaml:"acceptable,omitempty"`
+	Rules      Rules `yaml:"rules,omitempty,omitzero"`
+}
+
+type Rules struct {
 	Pipeline  Pipeline  `yaml:"pipeline,omitempty,omitzero"`
 	TailorDB  TailorDB  `yaml:"tailordb,omitempty,omitzero"`
 	StateFlow StateFlow `yaml:"stateflow,omitempty,omitzero"`

--- a/tailor/helper_test.go
+++ b/tailor/helper_test.go
@@ -12,39 +12,41 @@ func createTestConfig(t *testing.T) *config.Config {
 	return &config.Config{
 		WorkspaceID: "test-workspace-id",
 		Lint: config.Lint{
-			TailorDB: config.TailorDB{
-				DeprecatedFeature: config.TailorDBDeprecatedFeature{
-					Enabled:               true,
-					AllowDraft:            false,
-					AllowCELHooks:         false,
-					AllowTypePermission:   false,
-					AllowRecordPermission: false,
+			Rules: config.Rules{
+				TailorDB: config.TailorDB{
+					DeprecatedFeature: config.TailorDBDeprecatedFeature{
+						Enabled:               true,
+						AllowDraft:            false,
+						AllowCELHooks:         false,
+						AllowTypePermission:   false,
+						AllowRecordPermission: false,
+					},
 				},
-			},
-			Pipeline: config.Pipeline{
-				InsecureAuthorization: config.InsecureAuthorization{
-					Enabled: true,
+				Pipeline: config.Pipeline{
+					InsecureAuthorization: config.InsecureAuthorization{
+						Enabled: true,
+					},
+					StepLength: config.StepLength{
+						Enabled: true,
+						Max:     10,
+					},
+					DeprecatedFeature: config.PipelineDeprecatedFeature{
+						Enabled:        true,
+						AllowStateFlow: false,
+						AllowDraft:     false,
+						AllowCELScript: false,
+					},
+					MultipleMutations: config.MultipleMutations{
+						Enabled: true,
+					},
+					QueryBeforeMutation: config.QueryBeforeMutation{
+						Enabled: true,
+					},
 				},
-				StepLength: config.StepLength{
-					Enabled: true,
-					Max:     10,
-				},
-				DeprecatedFeature: config.PipelineDeprecatedFeature{
-					Enabled:        true,
-					AllowStateFlow: false,
-					AllowDraft:     false,
-					AllowCELScript: false,
-				},
-				MultipleMutations: config.MultipleMutations{
-					Enabled: true,
-				},
-				QueryBeforeMutation: config.QueryBeforeMutation{
-					Enabled: true,
-				},
-			},
-			StateFlow: config.StateFlow{
-				DeprecatedFeature: config.StateFlowDeprecatedFeature{
-					Enabled: true,
+				StateFlow: config.StateFlow{
+					DeprecatedFeature: config.StateFlowDeprecatedFeature{
+						Enabled: true,
+					},
 				},
 			},
 		},

--- a/tailor/lint_test.go
+++ b/tailor/lint_test.go
@@ -105,8 +105,8 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 		{
 			name: "draft feature warning",
 			configMod: func(c *config.Config) {
-				c.Lint.TailorDB.DeprecatedFeature.Enabled = true
-				c.Lint.TailorDB.DeprecatedFeature.AllowDraft = false
+				c.Lint.Rules.TailorDB.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.TailorDB.DeprecatedFeature.AllowDraft = false
 			},
 			resources: &Resources{
 				TailorDBs: []*TailorDB{
@@ -126,8 +126,8 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 		{
 			name: "legacy type permission warning",
 			configMod: func(c *config.Config) {
-				c.Lint.TailorDB.DeprecatedFeature.Enabled = true
-				c.Lint.TailorDB.DeprecatedFeature.AllowTypePermission = false
+				c.Lint.Rules.TailorDB.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.TailorDB.DeprecatedFeature.AllowTypePermission = false
 			},
 			resources: &Resources{
 				TailorDBs: []*TailorDB{
@@ -147,8 +147,8 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 		{
 			name: "legacy record permission warning",
 			configMod: func(c *config.Config) {
-				c.Lint.TailorDB.DeprecatedFeature.Enabled = true
-				c.Lint.TailorDB.DeprecatedFeature.AllowRecordPermission = false
+				c.Lint.Rules.TailorDB.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.TailorDB.DeprecatedFeature.AllowRecordPermission = false
 			},
 			resources: &Resources{
 				TailorDBs: []*TailorDB{
@@ -168,8 +168,8 @@ func TestClient_Lint_TailorDB(t *testing.T) {
 		{
 			name: "CEL hooks deprecated warning",
 			configMod: func(c *config.Config) {
-				c.Lint.TailorDB.DeprecatedFeature.Enabled = true
-				c.Lint.TailorDB.DeprecatedFeature.AllowCELHooks = false
+				c.Lint.Rules.TailorDB.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.TailorDB.DeprecatedFeature.AllowCELHooks = false
 			},
 			resources: &Resources{
 				TailorDBs: []*TailorDB{
@@ -240,7 +240,7 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 		{
 			name: "insecure authorization warning",
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.InsecureAuthorization.Enabled = true
+				c.Lint.Rules.Pipeline.InsecureAuthorization.Enabled = true
 			},
 			resources: &Resources{
 				Pipelines: []*Pipeline{
@@ -260,8 +260,8 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 		{
 			name: "step length warning",
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.StepLength.Enabled = true
-				c.Lint.Pipeline.StepLength.Max = 1
+				c.Lint.Rules.Pipeline.StepLength.Enabled = true
+				c.Lint.Rules.Pipeline.StepLength.Max = 1
 			},
 			resources: &Resources{
 				Pipelines: []*Pipeline{
@@ -284,8 +284,8 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 		{
 			name: "legacy script warnings",
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.DeprecatedFeature.Enabled = true
-				c.Lint.Pipeline.DeprecatedFeature.AllowCELScript = false
+				c.Lint.Rules.Pipeline.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.Pipeline.DeprecatedFeature.AllowCELScript = false
 			},
 			resources: &Resources{
 				Pipelines: []*Pipeline{
@@ -318,7 +318,7 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 		{
 			name: "invalid GraphQL syntax error",
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.Pipeline.DeprecatedFeature.Enabled = true
 			},
 			resources: &Resources{
 				Pipelines: []*Pipeline{
@@ -414,8 +414,8 @@ func TestClient_Lint_GraphQLParsing(t *testing.T) {
 			name:         "StateFlow mutation warning",
 			graphqlQuery: "mutation { newState(input: {status: \"active\"}) { id } }",
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.DeprecatedFeature.Enabled = true
-				c.Lint.Pipeline.DeprecatedFeature.AllowStateFlow = false
+				c.Lint.Rules.Pipeline.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.Pipeline.DeprecatedFeature.AllowStateFlow = false
 			},
 			expectedMsgs: []string{"StateFlow feature is deprecated (found usage of newState)"},
 		},
@@ -424,8 +424,8 @@ func TestClient_Lint_GraphQLParsing(t *testing.T) {
 			graphqlQuery: "mutation { appendDraftUser(input: {name: \"test\"}) { id } }",
 			typeNames:    []string{"User"},
 			configMod: func(c *config.Config) {
-				c.Lint.Pipeline.DeprecatedFeature.Enabled = true
-				c.Lint.Pipeline.DeprecatedFeature.AllowDraft = false
+				c.Lint.Rules.Pipeline.DeprecatedFeature.Enabled = true
+				c.Lint.Rules.Pipeline.DeprecatedFeature.AllowDraft = false
 			},
 			expectedMsgs: []string{"Draft feature is deprecated (found usage of appendDraftUser)"},
 		},
@@ -509,7 +509,7 @@ func TestClient_Lint_GraphQLParsing(t *testing.T) {
 
 func TestClient_Lint_StateFlow(t *testing.T) {
 	cfg := createTestConfig(t)
-	cfg.Lint.StateFlow.DeprecatedFeature.Enabled = true
+	cfg.Lint.Rules.StateFlow.DeprecatedFeature.Enabled = true
 
 	resources := &Resources{
 		StateFlows: []*StateFlow{
@@ -545,7 +545,7 @@ func TestClient_Lint_StateFlow(t *testing.T) {
 
 func TestClient_Lint_MultipleMutations(t *testing.T) {
 	cfg := createTestConfig(t)
-	cfg.Lint.Pipeline.MultipleMutations.Enabled = true
+	cfg.Lint.Rules.Pipeline.MultipleMutations.Enabled = true
 
 	resources := &Resources{
 		Pipelines: []*Pipeline{
@@ -599,7 +599,7 @@ func TestClient_Lint_MultipleMutations(t *testing.T) {
 
 func TestClient_Lint_QueryBeforeMutation(t *testing.T) {
 	cfg := createTestConfig(t)
-	cfg.Lint.Pipeline.QueryBeforeMutation.Enabled = true
+	cfg.Lint.Rules.Pipeline.QueryBeforeMutation.Enabled = true
 
 	resources := &Resources{
 		Pipelines: []*Pipeline{


### PR DESCRIPTION
This pull request refactors how lint configuration is structured and introduces a new feature to control the acceptable number of lint warnings before failing. The main changes are the introduction of an `acceptable` threshold for warnings, the grouping of all lint rules under a new `rules` field, and updates to both the code and documentation to reflect these changes.

Configuration structure improvements:

* Added an `acceptable` field to the lint configuration, allowing users to specify the maximum number of lint warnings before the command fails. This is documented in the `README.md` and implemented in the lint command logic. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R91) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117-R124) [[3]](diffhunk://#diff-c192182bd1736dfde898947b8eef754b5381e85cc177945f935c65b4b087b2ceL61-R64) [[4]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R17-R21)
* Refactored the configuration so that all lint rules are now grouped under a new `rules` field within the `lint` section, replacing the previous flat structure. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R17-R21) [[2]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL39-R54) [[3]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL63-R63) [[4]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL81-R81) [[5]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL91-R95) [[6]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL113-R115) [[7]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL126-R126) [[8]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL142-R142) [[9]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL173-R173) [[10]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL188-R188) [[11]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL201-R203)

Code and test updates:

* Updated all usages of lint rule configuration in the codebase to reference the new `rules` field, ensuring consistency and correctness. [[1]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL39-R54) [[2]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL63-R63) [[3]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL81-R81) [[4]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL91-R95) [[5]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL113-R115) [[6]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL126-R126) [[7]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL142-R142) [[8]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL173-R173) [[9]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL188-R188) [[10]](diffhunk://#diff-6d2fc3cafa671bcc3f1d90b0117f1f97e11a8c46f5115f34856321eae02275aaL201-R203)
* Updated all related tests to use the new `rules` field, ensuring tests reflect the new configuration structure and continue to validate linting logic. [[1]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL108-R109) [[2]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL129-R130) [[3]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL150-R151) [[4]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL171-R172) [[5]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL243-R243) [[6]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL263-R264) [[7]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL287-R288) [[8]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL321-R321) [[9]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL417-R418) [[10]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL427-R428) [[11]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL512-R512) [[12]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL548-R548) [[13]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL602-R602) [[14]](diffhunk://#diff-6cb9066d2205a07393310e94855f2cc4c49d309bf2d73a23199f012d96fac01bR15) [[15]](diffhunk://#diff-6cb9066d2205a07393310e94855f2cc4c49d309bf2d73a23199f012d96fac01bR52)

Documentation:

* Updated the `README.md` to document the new `acceptable` option and the new structure for specifying lint rules. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R90-R91) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R117-R124)

Other:

* Minor code cleanup: removed an unused import from `cmd/lint.go`.