### PR TITLE
fix: correct assignment of working directory path

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -106,7 +106,7 @@ func Load() (*Config, error) {
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		wd := filepath.Dir(wd)
+		wd = filepath.Dir(wd)
 		if wd == "/" || wd == "." {
 			break
 		}


### PR DESCRIPTION
This pull request makes a minor fix in the `config/config.go` file to correctly update the `wd` variable when traversing parent directories. This change ensures the variable is reassigned properly within the loop.

* Fixed a bug in the `Load` function by reassigning the `wd` variable instead of declaring a new one when moving up directory levels.