### PR TITLE
fix: rename stepLength to stepCount

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ lint:
         allowStateFlow: false
       insecureAuthorization:
         enabled: false
-      stepLength:
+      stepCount:
         enabled: true
         max: 30
       multipleMutations:
@@ -208,7 +208,7 @@ lint:
       - https://docs.tailor.tech/reference/service-lifecycle-policy
   - Enabled by default to promote migration away from deprecated features
 - **insecureAuthorization** - Detect insecure authorization patterns
-- **stepLength** - Ensure pipeline steps don't exceed maximum length
+- **stepCount** - Ensure pipeline steps don't exceed maximum count
 - **multipleMutations** - Identify multiple mutations in a single operation
 - **queryBeforeMutation** - Check for queries before mutations
 

--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ type Rules struct {
 type Pipeline struct {
 	DeprecatedFeature     PipelineDeprecatedFeature `yaml:"deprecatedFeature,omitempty,omitzero"`
 	InsecureAuthorization InsecureAuthorization     `yaml:"insecureAuthorization,omitempty,omitzero"`
-	StepLength            StepLength                `yaml:"stepLength,omitempty,omitzero"`
+	StepCount            StepCount                `yaml:"stepCount,omitempty,omitzero"`
 	MultipleMutations     MultipleMutations         `yaml:"multipleMutations,omitempty,omitzero"`
 	QueryBeforeMutation   QueryBeforeMutation       `yaml:"queryBeforeMutation,omitempty,omitzero"`
 }
@@ -43,7 +43,7 @@ type InsecureAuthorization struct {
 	Enabled bool `default:"true" yaml:"enabled,omitempty"`
 }
 
-type StepLength struct {
+type StepCount struct {
 	Enabled bool `default:"true" yaml:"enabled,omitempty"`
 	Max     int  `default:"30" yaml:"max,omitempty"`
 }

--- a/tailor/helper_test.go
+++ b/tailor/helper_test.go
@@ -26,7 +26,7 @@ func createTestConfig(t *testing.T) *config.Config {
 					InsecureAuthorization: config.InsecureAuthorization{
 						Enabled: true,
 					},
-					StepLength: config.StepLength{
+					StepCount: config.StepCount{
 						Enabled: true,
 						Max:     10,
 					},

--- a/tailor/lint.go
+++ b/tailor/lint.go
@@ -86,13 +86,13 @@ func (c *Client) Lint(resources *Resources) ([]*LintWarn, error) {
 				})
 			}
 
-			stepLength := len(r.Steps)
-			// Pipeline/StepLength
-			if c.cfg.Lint.Rules.Pipeline.StepLength.Enabled && stepLength > c.cfg.Lint.Rules.Pipeline.StepLength.Max {
+			stepCount := len(r.Steps)
+			// Pipeline/StepCount
+			if c.cfg.Lint.Rules.Pipeline.StepCount.Enabled && stepCount > c.cfg.Lint.Rules.Pipeline.StepCount.Max {
 				warns = append(warns, &LintWarn{
 					Type:    LintTargetTypePipeline,
 					Name:    fmt.Sprintf("%s/%s", p.NamespaceName, r.Name),
-					Message: fmt.Sprintf("resolver has too many steps (%d > %d)", stepLength, c.cfg.Lint.Rules.Pipeline.StepLength.Max),
+					Message: fmt.Sprintf("resolver has too many steps (%d > %d)", stepCount, c.cfg.Lint.Rules.Pipeline.StepCount.Max),
 				})
 			}
 

--- a/tailor/lint_test.go
+++ b/tailor/lint_test.go
@@ -260,8 +260,8 @@ func TestClient_Lint_Pipeline(t *testing.T) {
 		{
 			name: "step length warning",
 			configMod: func(c *config.Config) {
-				c.Lint.Rules.Pipeline.StepLength.Enabled = true
-				c.Lint.Rules.Pipeline.StepLength.Max = 1
+				c.Lint.Rules.Pipeline.StepCount.Enabled = true
+				c.Lint.Rules.Pipeline.StepCount.Max = 1
 			},
 			resources: &Resources{
 				Pipelines: []*Pipeline{


### PR DESCRIPTION
This pull request renames the pipeline linting rule from "StepLength" to "StepCount" throughout the codebase and documentation to better reflect its purpose (limiting the number of steps in a pipeline). The changes ensure consistency across configuration files, code, tests, and documentation.

**Renaming and Refactoring Pipeline Step Rule:**

* Renamed the struct `StepLength` to `StepCount` and updated its usage in the `config/config.go` file and related configuration logic. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L30-R30) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L46-R46)
* Updated all references in the codebase from `StepLength` to `StepCount`, including variable names, configuration fields, and logic in `tailor/lint.go`.
* Adjusted tests and test helpers to use `StepCount` instead of `StepLength`, ensuring tests reflect the new naming. [[1]](diffhunk://#diff-6cb9066d2205a07393310e94855f2cc4c49d309bf2d73a23199f012d96fac01bL29-R29) [[2]](diffhunk://#diff-af291f5f541961dbf54c8aabf9341a45a90e9e412566918423347815eec97a0fL263-R264)

**Documentation Updates:**

* Updated the documentation in `README.md` to replace "stepLength" with "stepCount" and revised descriptions to clarify that the rule limits the number of steps, not their length. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L174-R174) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L211-R211)