### PR TITLE
docs: since the GitHub UI has Contributing and License tabs, they are  unnecessary in the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,12 +249,6 @@ lint:
 - `patterner metrics` - Display workspace metrics
 - `patterner coverage` - Display pipeline resolver step coverage
 
-## License
-
-This repository is licensed under the [MIT License](LICENSE).
-
-## Contributing
-
-For contributions, please see [CONTRIBUTING.md](CONTRIBUTING.md).
+---
 
 Copyright © 2025 Tailor Inc.


### PR DESCRIPTION
This pull request updates the `README.md` to simplify the end section by removing the License and Contributing sections, and replacing them with a copyright notice.

- Documentation update:
  * Removed the License and Contributing sections from the end of `README.md` and added a copyright notice for Tailor Inc.