### PR TITLE
feat: add support for configurable acceptable thresholds in octocov output

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ export TAILOR_TOKEN=your_access_token
 patterner metrics
 ```
 
-The metrics command displays metrics in a table format. Use the `--out-octocov-path` option to output metrics in octocov custom metrics format.
+The metrics command displays metrics in a table format. Use the `--out-octocov-path` option to output metrics in octocov custom metrics format with configurable acceptable thresholds.
 
 #### Metrics Options
 
@@ -122,6 +122,43 @@ patterner metrics --out-octocov-path metrics.json
 
 # Comprehensive analysis with all options
 patterner metrics --since 24hours --out-octocov-path metrics.json --with-coverage-full-report --with-lint-warnings
+```
+
+#### Octocov Custom Metrics Format
+
+When using the `--out-octocov-path` option, patterner outputs metrics in octocov custom metrics format. This format includes:
+
+- **Metrics data** - All collected metrics with their values and units
+- **Acceptable thresholds** - Configurable conditions that define acceptable metric values
+  - Configured via `metrics.octocov.acceptables` in `.patterner.yml`
+  - Used by [octocov](https://github.com/k1LoW/octocov) to evaluate whether metrics meet quality standards
+
+**Example octocov output:**
+```json
+[
+  {
+    "key": "patterner-metrics",
+    "name": "Patterner Metrics",
+    "metrics": [
+      {
+        "key": "pipeline_resolver_step_coverage_percentage",
+        "name": "Pipeline Resolver Step Coverage",
+        "value": 75.0,
+        "unit": "%"
+      },
+      {
+        "key": "lint_warnings_total",
+        "name": "Lint Warnings Total",
+        "value": 3,
+        "unit": "count"
+      }
+    ],
+    "acceptables": [
+      "pipeline_resolver_step_coverage_percentage >= 80",
+      "lint_warnings_total <= 5"
+    ]
+  }
+]
 ```
 
 **Implementation Notes:**
@@ -252,7 +289,24 @@ lint:
     stateflow:
       deprecatedFeature:
         enabled: true
+metrics:
+  octocov:
+    acceptables:
+      - "current.pipeline_resolver_step_coverage_percentage >= 80"
+      - "diff.lint_warnings_total <= 0"
 ```
+
+### Metrics Configuration
+
+#### Octocov Integration
+
+- **octocov** - Configuration for octocov custom metrics format output
+  - `acceptables` - List of acceptable threshold conditions for metrics
+    - Define minimum acceptable values for metrics in octocov format
+    - Used when outputting metrics with `--out-octocov-path` option
+    - Format: `"metric_name operator value"` (e.g., `"coverage_percentage >= 80"`)
+    - Supports various metrics including coverage percentages and lint warning counts
+    - Example: `["pipeline_resolver_step_coverage_percentage >= 80", "lint_warnings_total <= 5"]`
 
 ### Lint Configuration
 

--- a/cmd/metrics.go
+++ b/cmd/metrics.go
@@ -188,6 +188,8 @@ var metricsCmd = &cobra.Command{
 					Unit:  m.Unit,
 				})
 			}
+			metricSet.Acceptables = append(metricSet.Acceptables, cfg.Metrics.Octocov.Acceptables...)
+
 			csets := []*CustomMetricSet{metricSet}
 			b, err := json.MarshalIndent(csets, "", "  ")
 			if err != nil {
@@ -219,10 +221,11 @@ type MetadataKV struct {
 }
 
 type CustomMetricSet struct {
-	Key      string          `json:"key"`
-	Name     string          `json:"name,omitempty"`
-	Metadata []*MetadataKV   `json:"metadata,omitempty"`
-	Metrics  []*CustomMetric `json:"metrics"`
+	Key         string          `json:"key"`
+	Name        string          `json:"name,omitempty"`
+	Metadata    []*MetadataKV   `json:"metadata,omitempty"`
+	Metrics     []*CustomMetric `json:"metrics"`
+	Acceptables []string        `json:"acceptables,omitempty"`
 }
 
 type CustomMetric struct {

--- a/config/config.go
+++ b/config/config.go
@@ -9,8 +9,9 @@ import (
 )
 
 type Config struct {
-	WorkspaceID string `default:"" yaml:"workspaceID,omitempty"`
-	Lint        Lint   `yaml:"lint,omitempty"`
+	WorkspaceID string  `default:"" yaml:"workspaceID,omitempty"`
+	Lint        Lint    `yaml:"lint,omitempty"`
+	Metrics     Metrics `yaml:"metrics,omitempty"`
 }
 
 type Lint struct {
@@ -27,7 +28,7 @@ type Rules struct {
 type Pipeline struct {
 	DeprecatedFeature     PipelineDeprecatedFeature `yaml:"deprecatedFeature,omitempty,omitzero"`
 	InsecureAuthorization InsecureAuthorization     `yaml:"insecureAuthorization,omitempty,omitzero"`
-	StepCount            StepCount                `yaml:"stepCount,omitempty,omitzero"`
+	StepCount             StepCount                 `yaml:"stepCount,omitempty,omitzero"`
 	MultipleMutations     MultipleMutations         `yaml:"multipleMutations,omitempty,omitzero"`
 	QueryBeforeMutation   QueryBeforeMutation       `yaml:"queryBeforeMutation,omitempty,omitzero"`
 }
@@ -74,6 +75,14 @@ type StateFlow struct {
 
 type StateFlowDeprecatedFeature struct {
 	Enabled bool `default:"true" yaml:"enabled,omitempty"`
+}
+
+type Metrics struct {
+	Octocov Octocov `yaml:"octocov,omitempty,omitzero"`
+}
+
+type Octocov struct {
+	Acceptables []string `yaml:"acceptables,omitempty"`
 }
 
 const Filename = ".patterner.yml"


### PR DESCRIPTION
This pull request adds support for configurable acceptable metric thresholds when exporting metrics in the octocov custom metrics format. Users can now define acceptable threshold conditions for their metrics in the `.patterner.yml` configuration file, and these thresholds will be included in the output when using the `--out-octocov-path` option. The documentation has been updated to explain the new configuration and output format.

**Octocov integration and configuration:**

* Added a new `metrics.octocov.acceptables` section to `.patterner.yml` for specifying acceptable metric thresholds, which are included in the octocov custom metrics output. [[1]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R14) [[2]](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R80-R87) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R292-R310)

**Code changes to support acceptables:**

* Updated the `CustomMetricSet` struct and metrics command implementation to include the `acceptables` field in the octocov output, pulling values from the config. [[1]](diffhunk://#diff-f6c02caa274ef7b49035007ea236c9e702cff896743ff7cb1b05407b0fec31caR228) [[2]](diffhunk://#diff-f6c02caa274ef7b49035007ea236c9e702cff896743ff7cb1b05407b0fec31caR191-R192)

**Documentation updates:**

* Expanded the `README.md` to document the new octocov custom metrics format, how to configure acceptable thresholds, and provided an example output. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L82-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R127-R163) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R292-R310)