### PR TITLE
feat: add metrics `pipeline_resolver_graphql_steps_total` and `pipeline_resolver_function_steps_total`

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,8 @@ The following metrics are collected and displayed:
 - `pipelines_total` - Total number of pipelines (Unit: count)
 - `pipeline_resolvers_total` - Total number of pipeline resolvers (Unit: count)
 - `pipeline_resolver_steps_total` - Total number of pipeline resolver steps (Unit: count)
+- `pipeline_resolver_graphql_steps_total` - Total number of Pipeline resolver GraphQL steps (Unit: count)
+- `pipeline_resolver_function_steps_total` - Total number of Pipeline resolver Function steps (Unit: count)
 - `pipeline_resolver_execution_paths_total` - Total number of pipeline resolver execution paths (Unit: count)
   - Calculation: Based on the number of steps and tests in each resolver (steps \* 2^tests)
   - Includes overflow detection: Reports error if negative values are encountered


### PR DESCRIPTION
This pull request adds new metrics to track the number of GraphQL and Function steps within pipeline resolvers, updates the documentation accordingly, and introduces comprehensive tests to ensure correct metric calculation and coverage of edge cases.

**Metrics collection enhancements:**

* Added two new metrics: `pipeline_resolver_graphql_steps_total` and `pipeline_resolver_function_steps_total`, which count the number of GraphQL and Function steps in all pipeline resolvers, respectively. [[1]](diffhunk://#diff-290b69c710ec0631005d399a536ba9887b07952b0a118186c89f55656edfa676R69-R70) [[2]](diffhunk://#diff-290b69c710ec0631005d399a536ba9887b07952b0a118186c89f55656edfa676R81-R86) [[3]](diffhunk://#diff-290b69c710ec0631005d399a536ba9887b07952b0a118186c89f55656edfa676R103-R115)
* Updated the `README.md` to document these new metrics and their purpose.

**Testing improvements:**

* Updated existing metric tests to include the new metrics and ensure they are present in all test cases. [[1]](diffhunk://#diff-8c53b3fb8b96b0f028b60541c0d3a16ebe600c1d296b1fad07e8008369470722R29-R30) [[2]](diffhunk://#diff-8c53b3fb8b96b0f028b60541c0d3a16ebe600c1d296b1fad07e8008369470722R77-R78) [[3]](diffhunk://#diff-8c53b3fb8b96b0f028b60541c0d3a16ebe600c1d296b1fad07e8008369470722R168-R169) [[4]](diffhunk://#diff-8c53b3fb8b96b0f028b60541c0d3a16ebe600c1d296b1fad07e8008369470722R214-R215) [[5]](diffhunk://#diff-8c53b3fb8b96b0f028b60541c0d3a16ebe600c1d296b1fad07e8008369470722R602-R603)
* Added a new test suite (`TestClient_Metrics_StepTypes`) covering various scenarios for GraphQL and Function step counting, including mixed types, only one type, empty resources, and resolvers with no steps.

